### PR TITLE
Fix shell command injection: escape all interpolated values before exec()

### DIFF
--- a/scripts/verify-command-injection-fix.mjs
+++ b/scripts/verify-command-injection-fix.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+// Standalone reproduction + verification for the command-injection report.
+//
+// Run: node scripts/verify-command-injection-fix.mjs
+//
+// Reproduces the exact command-construction + exec() path used by
+// src/utils/sfCommand.ts (substituting `echo` for the real `sf` binary,
+// same as the original disclosure — no live Salesforce org touched),
+// against both the vulnerable pattern and the shq()-escaped one.
+
+import { exec } from "node:child_process";
+import { existsSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const shq = (value) => `'${String(value).replace(/'/g, `'\\''`)}'`;
+
+const marker = join(tmpdir(), `sf-mcp-poc-${Date.now()}`);
+rmSync(marker, { force: true });
+
+// The exact payload from the original disclosure email.
+const maliciousQuery = `FIND {test}" ; touch ${marker} ; echo "`;
+
+function run(command) {
+    return new Promise((resolve) => {
+        exec(command, (error, stdout, stderr) =>
+            resolve({ error, stdout, stderr }),
+        );
+    });
+}
+
+async function main() {
+    console.log("=== 1. VULNERABLE pattern (before fix) ===");
+    const vulnerableCommand = `echo data query --target-org myOrg --query "${maliciousQuery}" --json`;
+    console.log("Constructed command:", vulnerableCommand);
+    await run(vulnerableCommand);
+    const vulnerableExploited = existsSync(marker);
+    console.log(
+        vulnerableExploited
+            ? "RESULT: injected `touch` executed -> marker file created. Confirms the original report.\n"
+            : "RESULT: marker file NOT created (unexpected — re-check payload).\n",
+    );
+    rmSync(marker, { force: true });
+
+    console.log("=== 2. FIXED pattern (shq(), this PR) ===");
+    const fixedCommand = `echo data query --target-org ${shq("myOrg")} --query ${shq(maliciousQuery)} --json`;
+    console.log("Constructed command:", fixedCommand);
+    await run(fixedCommand);
+    const fixedExploited = existsSync(marker);
+    console.log(
+        fixedExploited
+            ? "RESULT: marker file created — FIX DID NOT WORK.\n"
+            : "RESULT: no marker file. The payload reached `echo` as inert single-quoted text, not shell syntax.\n",
+    );
+    rmSync(marker, { force: true });
+
+    const passed = vulnerableExploited && !fixedExploited;
+    console.log(passed ? "PASS" : "FAIL");
+    process.exit(passed ? 0 : 1);
+}
+
+main();

--- a/src/tools/apex.ts
+++ b/src/tools/apex.ts
@@ -12,6 +12,7 @@ import {
 } from "@salesforce/apex-node";
 import { getConnection } from "../shared/connection.js";
 import { permissions } from "../config/permissions.js";
+import { shq } from "../utils/shellEscape.js";
 import { executeSfCommand } from "../utils/sfCommand.js";
 import { resolveTargetOrg } from "../utils/resolveTargetOrg.js";
 import { createProgressReporter, type ToolExtra } from "../utils/progress.js";
@@ -209,10 +210,10 @@ const getCodeCoverage = async (
 };
 
 const generateClass = async (name: string, outputDir: string) => {
-    let sfCommand = `sf apex generate class --name ${name} --json `;
+    let sfCommand = `sf apex generate class --name ${shq(name)} --json `;
 
     if (outputDir && outputDir.length > 0) {
-        sfCommand += `--output-dir ${outputDir}`;
+        sfCommand += `--output-dir ${shq(outputDir)}`;
     }
 
     try {
@@ -228,14 +229,14 @@ const generateTrigger = async (
     sObjectName: string,
     outputDir: string,
 ) => {
-    let sfCommand = `sf apex generate trigger --name ${name} --json `;
+    let sfCommand = `sf apex generate trigger --name ${shq(name)} --json `;
 
     if (sObjectName && sObjectName.length > 0) {
-        sfCommand += `--sobject ${sObjectName} `;
+        sfCommand += `--sobject ${shq(sObjectName)} `;
     }
 
     if (outputDir && outputDir.length > 0) {
-        sfCommand += `--output-dir ${outputDir}`;
+        sfCommand += `--output-dir ${shq(outputDir)}`;
     }
 
     try {
@@ -247,7 +248,7 @@ const generateTrigger = async (
 };
 
 const apexLogList = async (targetOrg: string) => {
-    let sfCommand = `sf apex log list --target-org ${targetOrg} --json `;
+    let sfCommand = `sf apex log list --target-org ${shq(targetOrg)} --json `;
 
     try {
         const result = await executeSfCommand(sfCommand);
@@ -262,16 +263,16 @@ const apexGetLog = async (
     logId: string,
     recentLogsNumber: number,
 ) => {
-    let sfCommand = `sf apex get log --target-org ${targetOrg} --json `;
+    let sfCommand = `sf apex get log --target-org ${shq(targetOrg)} --json `;
 
     const hasLogId = logId && logId.length > 0;
 
     if (hasLogId) {
-        sfCommand += `--log-id ${logId} `;
+        sfCommand += `--log-id ${shq(logId)} `;
     }
 
     if (!hasLogId && recentLogsNumber !== 0) {
-        sfCommand += `--number ${recentLogsNumber}`;
+        sfCommand += `--number ${shq(recentLogsNumber)}`;
     }
 
     try {

--- a/src/tools/code-analyzer.ts
+++ b/src/tools/code-analyzer.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { shq } from "../utils/shellEscape.js";
 import { executeSfCommandRaw } from "../utils/sfCommand.js";
 import { permissions } from "../config/permissions.js";
 import { createProgressReporter, type ToolExtra } from "../utils/progress.js";
@@ -16,32 +17,32 @@ const runCodeAnalyzer = async (
 
     if (workspace && workspace.length > 0) {
         workspace.forEach((w) => {
-            command += ` --workspace "${w}"`;
+            command += ` --workspace ${shq(w)}`;
         });
     }
 
     if (target && target.length > 0) {
         target.forEach((t) => {
-            command += ` --target "${t}"`;
+            command += ` --target ${shq(t)}`;
         });
     }
 
     if (outputFile) {
-        command += ` --output-file "${outputFile}"`;
+        command += ` --output-file ${shq(outputFile)}`;
     }
 
     if (ruleSelector && ruleSelector.length > 0) {
         ruleSelector.forEach((rs) => {
-            command += ` --rule-selector "${rs}"`;
+            command += ` --rule-selector ${shq(rs)}`;
         });
     }
 
     if (severity) {
-        command += ` --severity-threshold ${severity}`;
+        command += ` --severity-threshold ${shq(severity)}`;
     }
 
     if (configFile) {
-        command += ` --config-file "${configFile}"`;
+        command += ` --config-file ${shq(configFile)}`;
     }
 
     const result = await executeSfCommandRaw(command);
@@ -59,28 +60,28 @@ const listCodeAnalyzerRules = async (
 
     if (workspace && workspace.length > 0) {
         workspace.forEach((w) => {
-            command += ` --workspace "${w}"`;
+            command += ` --workspace ${shq(w)}`;
         });
     }
 
     if (target && target.length > 0) {
         target.forEach((t) => {
-            command += ` --target "${t}"`;
+            command += ` --target ${shq(t)}`;
         });
     }
 
     if (configFile) {
-        command += ` --config-file "${configFile}"`;
+        command += ` --config-file ${shq(configFile)}`;
     }
 
     if (ruleSelector && ruleSelector.length > 0) {
         ruleSelector.forEach((rs) => {
-            command += ` --rule-selector "${rs}"`;
+            command += ` --rule-selector ${shq(rs)}`;
         });
     }
 
     if (view) {
-        command += ` --view ${view}`;
+        command += ` --view ${shq(view)}`;
     }
 
     const result = await executeSfCommandRaw(command);

--- a/src/tools/lightning.ts
+++ b/src/tools/lightning.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { getConnection } from "../shared/connection.js";
 import { permissions } from "../config/permissions.js";
+import { shq } from "../utils/shellEscape.js";
 import { executeSfCommand, executeSfCommandRaw } from "../utils/sfCommand.js";
 
 const generateComponent = async (
@@ -10,18 +11,18 @@ const generateComponent = async (
     outputDirectory: string,
     type: string,
 ) => {
-    let sfCommand = `sf lightning generate component --name ${name} --json `;
+    let sfCommand = `sf lightning generate component --name ${shq(name)} --json `;
 
     if (template && template.length > 0) {
-        sfCommand += `--template ${template} `;
+        sfCommand += `--template ${shq(template)} `;
     }
 
     if (outputDirectory && outputDirectory.length > 0) {
-        sfCommand += `--output-dir ${outputDirectory} `;
+        sfCommand += `--output-dir ${shq(outputDirectory)} `;
     }
 
     if (type && type.length > 0) {
-        sfCommand += `--type ${type}`;
+        sfCommand += `--type ${shq(type)}`;
     }
 
     try {

--- a/src/tools/orgs.ts
+++ b/src/tools/orgs.ts
@@ -1,6 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { listAllOrgs } from "../shared/connection.js";
 import { permissions } from "../config/permissions.js";
+import { shq } from "../utils/shellEscape.js";
 import { executeSfCommand } from "../utils/sfCommand.js";
 import {
     resolveTargetOrg,
@@ -63,7 +64,7 @@ const listConnectedSalesforceOrgs = async () => {
 };
 
 const loginIntoOrg = async (alias: string, isProduction: boolean) => {
-    let sfCommand = `sf org login web -a ${alias} --json `;
+    let sfCommand = `sf org login web -a ${shq(alias)} --json `;
     sfCommand += isProduction
         ? `-r https://login.salesforce.com`
         : `-r https://test.salesforce.com`;
@@ -81,15 +82,15 @@ const assignPermissionSet = async (
     permissionSetNames: string[],
     onBehalfOf?: string[],
 ) => {
-    let sfCommand = `sf org assign permset --target-org ${targetOrg}`;
+    let sfCommand = `sf org assign permset --target-org ${shq(targetOrg)}`;
 
     permissionSetNames.forEach((name) => {
-        sfCommand += ` --name "${name}"`;
+        sfCommand += ` --name ${shq(name)}`;
     });
 
     if (onBehalfOf && onBehalfOf.length > 0) {
         onBehalfOf.forEach((user) => {
-            sfCommand += ` --on-behalf-of "${user}"`;
+            sfCommand += ` --on-behalf-of ${shq(user)}`;
         });
     }
 
@@ -108,15 +109,15 @@ const assignPermissionSetLicense = async (
     licenseNames: string[],
     onBehalfOf?: string[],
 ) => {
-    let sfCommand = `sf org assign permsetlicense --target-org ${targetOrg}`;
+    let sfCommand = `sf org assign permsetlicense --target-org ${shq(targetOrg)}`;
 
     licenseNames.forEach((name) => {
-        sfCommand += ` --name "${name}"`;
+        sfCommand += ` --name ${shq(name)}`;
     });
 
     if (onBehalfOf && onBehalfOf.length > 0) {
         onBehalfOf.forEach((user) => {
-            sfCommand += ` --on-behalf-of "${user}"`;
+            sfCommand += ` --on-behalf-of ${shq(user)}`;
         });
     }
 
@@ -131,7 +132,7 @@ const assignPermissionSetLicense = async (
 };
 
 const displayUserInfo = async (targetOrg: string) => {
-    const sfCommand = `sf org display user --target-org ${targetOrg} --json`;
+    const sfCommand = `sf org display user --target-org ${shq(targetOrg)} --json`;
 
     try {
         const result = await executeSfCommand(sfCommand);
@@ -148,18 +149,18 @@ const listMetadata = async (
     apiVersion?: string,
     outputFile?: string,
 ) => {
-    let sfCommand = `sf org list metadata --target-org ${targetOrg} --metadata-type ${metadataType}`;
+    let sfCommand = `sf org list metadata --target-org ${shq(targetOrg)} --metadata-type ${shq(metadataType)}`;
 
     if (folder) {
-        sfCommand += ` --folder "${folder}"`;
+        sfCommand += ` --folder ${shq(folder)}`;
     }
 
     if (apiVersion) {
-        sfCommand += ` --api-version ${apiVersion}`;
+        sfCommand += ` --api-version ${shq(apiVersion)}`;
     }
 
     if (outputFile) {
-        sfCommand += ` --output-file "${outputFile}"`;
+        sfCommand += ` --output-file ${shq(outputFile)}`;
     }
 
     sfCommand += ` --json`;
@@ -177,14 +178,14 @@ const listMetadataTypes = async (
     apiVersion?: string,
     outputFile?: string,
 ) => {
-    let sfCommand = `sf org list metadata-types --target-org ${targetOrg}`;
+    let sfCommand = `sf org list metadata-types --target-org ${shq(targetOrg)}`;
 
     if (apiVersion) {
-        sfCommand += ` --api-version ${apiVersion}`;
+        sfCommand += ` --api-version ${shq(apiVersion)}`;
     }
 
     if (outputFile) {
-        sfCommand += ` --output-file "${outputFile}"`;
+        sfCommand += ` --output-file ${shq(outputFile)}`;
     }
 
     sfCommand += ` --json`;
@@ -203,7 +204,7 @@ const logoutFromOrg = async (targetOrg?: string, all?: boolean) => {
     if (all) {
         sfCommand += ` --all`;
     } else if (targetOrg) {
-        sfCommand += ` --target-org ${targetOrg}`;
+        sfCommand += ` --target-org ${shq(targetOrg)}`;
     }
 
     sfCommand += ` --no-prompt --json`;
@@ -223,14 +224,14 @@ const openOrg = async (
     privateMode?: boolean,
     sourceFile?: string,
 ) => {
-    let sfCommand = `sf org open --target-org ${targetOrg}`;
+    let sfCommand = `sf org open --target-org ${shq(targetOrg)}`;
 
     if (path) {
-        sfCommand += ` --path "${path}"`;
+        sfCommand += ` --path ${shq(path)}`;
     }
 
     if (browser) {
-        sfCommand += ` --browser ${browser}`;
+        sfCommand += ` --browser ${shq(browser)}`;
     }
 
     if (privateMode) {
@@ -238,7 +239,7 @@ const openOrg = async (
     }
 
     if (sourceFile) {
-        sfCommand += ` --source-file "${sourceFile}"`;
+        sfCommand += ` --source-file ${shq(sourceFile)}`;
     }
 
     sfCommand += ` --json`;
@@ -255,7 +256,7 @@ const generateFrontdoorUrl = async (
     targetOrg: string,
     retURL: string = "/",
 ) => {
-    const sfCommand = `sf org display --target-org ${targetOrg} --json`;
+    const sfCommand = `sf org display --target-org ${shq(targetOrg)} --json`;
     const result = await executeSfCommand(sfCommand);
 
     const instanceUrl = result?.result?.instanceUrl;
@@ -1191,7 +1192,7 @@ export const registerOrgTools = (server: McpServer) => {
 
             try {
                 const result = await executeSfCommand(
-                    `sf config set target-org=${targetOrg} --json`,
+                    `sf config set target-org=${shq(targetOrg)} --json`,
                 );
                 clearDefaultOrgCache();
                 return {

--- a/src/tools/package.ts
+++ b/src/tools/package.ts
@@ -1,5 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import { shq } from "../utils/shellEscape.js";
 import { executeSfCommand } from "../utils/sfCommand.js";
 import { permissions } from "../config/permissions.js";
 import { resolveTargetOrg } from "../utils/resolveTargetOrg.js";
@@ -16,34 +17,34 @@ const executePackageInstall = async (
     upgradeType: "DeprecateOnly" | "Mixed" | "Delete" = "Mixed",
     apiVersion?: string,
 ) => {
-    let sfCommand = `sf package install --package ${packageId} --target-org ${targetOrg} --no-prompt --json`;
+    let sfCommand = `sf package install --package ${shq(packageId)} --target-org ${shq(targetOrg)} --no-prompt --json`;
 
     if (wait > 0) {
-        sfCommand += ` --wait ${wait}`;
+        sfCommand += ` --wait ${shq(wait)}`;
     }
 
     if (installationKey) {
-        sfCommand += ` --installation-key ${installationKey}`;
+        sfCommand += ` --installation-key ${shq(installationKey)}`;
     }
 
     if (publishWait > 0) {
-        sfCommand += ` --publish-wait ${publishWait}`;
+        sfCommand += ` --publish-wait ${shq(publishWait)}`;
     }
 
     if (apexCompile) {
-        sfCommand += ` --apex-compile ${apexCompile}`;
+        sfCommand += ` --apex-compile ${shq(apexCompile)}`;
     }
 
     if (securityType) {
-        sfCommand += ` --security-type ${securityType}`;
+        sfCommand += ` --security-type ${shq(securityType)}`;
     }
 
     if (upgradeType) {
-        sfCommand += ` --upgrade-type ${upgradeType}`;
+        sfCommand += ` --upgrade-type ${shq(upgradeType)}`;
     }
 
     if (apiVersion) {
-        sfCommand += ` --api-version ${apiVersion}`;
+        sfCommand += ` --api-version ${shq(apiVersion)}`;
     }
 
     try {
@@ -60,14 +61,14 @@ const executePackageUninstall = async (
     wait: number = 0,
     apiVersion?: string,
 ) => {
-    let sfCommand = `sf package uninstall --package ${packageId} --target-org ${targetOrg} --json`;
+    let sfCommand = `sf package uninstall --package ${shq(packageId)} --target-org ${shq(targetOrg)} --json`;
 
     if (wait > 0) {
-        sfCommand += ` --wait ${wait}`;
+        sfCommand += ` --wait ${shq(wait)}`;
     }
 
     if (apiVersion) {
-        sfCommand += ` --api-version ${apiVersion}`;
+        sfCommand += ` --api-version ${shq(apiVersion)}`;
     }
 
     try {

--- a/src/tools/project.ts
+++ b/src/tools/project.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { permissions } from "../config/permissions.js";
+import { shq } from "../utils/shellEscape.js";
 import { executeSfCommand } from "../utils/sfCommand.js";
 import { resolveTargetOrg } from "../utils/resolveTargetOrg.js";
 import { requestConfirmation } from "../utils/elicitation.js";
@@ -17,22 +18,22 @@ const deployStart = async (
     tests: string,
     testLevel: string,
 ) => {
-    let sfCommand = `sf project deploy start --target-org ${targetOrg} --json `;
+    let sfCommand = `sf project deploy start --target-org ${shq(targetOrg)} --json `;
 
     if (dryRun) {
         sfCommand += `--dry-run `;
     }
 
     if (manifest && manifest.length > 0) {
-        sfCommand += `--manifest ${manifest} `;
+        sfCommand += `--manifest ${shq(manifest)} `;
     }
 
     if (metadata && metadata.length > 0) {
-        sfCommand += `--metadata ${metadata} `;
+        sfCommand += `--metadata ${shq(metadata)} `;
     }
 
     if (metadataDirectory && metadataDirectory.length > 0) {
-        sfCommand += `--metadata-dir ${metadataDirectory} `;
+        sfCommand += `--metadata-dir ${shq(metadataDirectory)} `;
     }
 
     if (singlePackage) {
@@ -40,15 +41,15 @@ const deployStart = async (
     }
 
     if (sourceDirectory && sourceDirectory.length > 0) {
-        sfCommand += `--source-dir ${sourceDirectory} `;
+        sfCommand += `--source-dir ${shq(sourceDirectory)} `;
     }
 
     if (tests && tests.length > 0) {
-        sfCommand += `--tests ${tests} `;
+        sfCommand += `--tests ${shq(tests)} `;
     }
 
     if (testLevel && testLevel.length > 0) {
-        sfCommand += `--test-level ${testLevel} `;
+        sfCommand += `--test-level ${shq(testLevel)} `;
     }
 
     try {

--- a/src/tools/query.ts
+++ b/src/tools/query.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { executeSfCommand } from "../utils/sfCommand.js";
+import { shq } from "../utils/shellEscape.js";
 import { permissions } from "../config/permissions.js";
 import { resolveTargetOrg } from "../utils/resolveTargetOrg.js";
 import { createProgressReporter, type ToolExtra } from "../utils/progress.js";
@@ -38,7 +39,7 @@ const executeSoqlQuery = async (
     if (orderBy) query += " ORDER BY " + orderBy;
     if (limit) query += " LIMIT " + limit;
 
-    const sfCommand = `sf data query --target-org ${targetOrg} --query "${query}" --json`;
+    const sfCommand = `sf data query --target-org ${shq(targetOrg)} --query ${shq(query)} --json`;
 
     const result = await executeSfCommand(sfCommand);
     if (result?.status !== 0 || !result?.result) {
@@ -61,9 +62,9 @@ const executeSoqlQueryToFile = async (
     if (where) query += " WHERE " + where;
     if (orderBy) query += " ORDER BY " + orderBy;
 
-    const sfCommand = `sf data export bulk --query "${query}" --target-org ${targetOrg} --output-file "${
-        outputFileName || "output"
-    }" --result-format ${outputFileFormat} --json -w 30`;
+    const sfCommand = `sf data export bulk --query ${shq(query)} --target-org ${shq(targetOrg)} --output-file ${shq(
+        outputFileName || "output",
+    )} --result-format ${shq(outputFileFormat)} --json -w 30`;
 
     const result = await executeSfCommand(sfCommand);
     if (result?.status !== 0 || !result?.result) {

--- a/src/tools/records.ts
+++ b/src/tools/records.ts
@@ -5,6 +5,7 @@ import { resolveTargetOrg } from "../utils/resolveTargetOrg.js";
 import { requestConfirmation } from "../utils/elicitation.js";
 import { exec } from "node:child_process";
 import { platform } from "node:os";
+import { shq } from "../utils/shellEscape.js";
 import z from "zod";
 
 /**
@@ -227,13 +228,19 @@ const openRecordInBrowser = async (
 
     switch (currentPlatform) {
         case "darwin":
-            command = `open "${url}"`;
+            command = `open ${shq(url)}`;
             break;
         case "win32":
+            // cmd.exe's quoting rules differ from POSIX shells (shq() targets
+            // /bin/sh); `start` is fine here since the URL only ever contains
+            // an instance URL + a caller-supplied recordId (checked non-empty
+            // above), but a caller-supplied `&|<>^%` etc. could still break
+            // out of the unescaped "" title argument. Left as-is pending a
+            // Windows-specific escaper — flagging for follow-up.
             command = `start "" "${url}"`;
             break;
         default:
-            command = `xdg-open "${url}"`;
+            command = `xdg-open ${shq(url)}`;
             break;
     }
 

--- a/src/tools/scanner.ts
+++ b/src/tools/scanner.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { shq } from "../utils/shellEscape.js";
 import { executeSfCommandRaw } from "../utils/sfCommand.js";
 import { permissions } from "../config/permissions.js";
 import { createProgressReporter, type ToolExtra } from "../utils/progress.js";
@@ -22,39 +23,39 @@ const runScanner = async (
     let command = "sf scanner run";
 
     if (target && target.length > 0) {
-        command += ` --target "${target.join(",")}"`;
+        command += ` --target ${shq(target.join(","))}`;
     }
 
     if (category && category.length > 0) {
-        command += ` --category "${category.join(",")}"`;
+        command += ` --category ${shq(category.join(","))}`;
     }
 
     if (engine && engine.length > 0) {
-        command += ` --engine "${engine.join(",")}"`;
+        command += ` --engine ${shq(engine.join(","))}`;
     }
 
     if (eslintConfig) {
-        command += ` --eslintconfig "${eslintConfig}"`;
+        command += ` --eslintconfig ${shq(eslintConfig)}`;
     }
 
     if (pmdConfig) {
-        command += ` --pmdconfig "${pmdConfig}"`;
+        command += ` --pmdconfig ${shq(pmdConfig)}`;
     }
 
     if (tsConfig) {
-        command += ` --tsconfig "${tsConfig}"`;
+        command += ` --tsconfig ${shq(tsConfig)}`;
     }
 
     if (format) {
-        command += ` --format ${format}`;
+        command += ` --format ${shq(format)}`;
     }
 
     if (outfile) {
-        command += ` --outfile "${outfile}"`;
+        command += ` --outfile ${shq(outfile)}`;
     }
 
     if (severityThreshold !== undefined) {
-        command += ` --severity-threshold ${severityThreshold}`;
+        command += ` --severity-threshold ${shq(severityThreshold)}`;
     }
 
     if (normalizeSeverity) {
@@ -62,7 +63,7 @@ const runScanner = async (
     }
 
     if (projectDir && projectDir.length > 0) {
-        command += ` --projectdir "${projectDir.join(",")}"`;
+        command += ` --projectdir ${shq(projectDir.join(","))}`;
     }
 
     if (verbose) {
@@ -96,27 +97,27 @@ const runScannerDfa = async (
     let command = "sf scanner run dfa";
 
     if (target && target.length > 0) {
-        command += ` --target "${target.join(",")}"`;
+        command += ` --target ${shq(target.join(","))}`;
     }
 
     if (projectDir && projectDir.length > 0) {
-        command += ` --projectdir "${projectDir.join(",")}"`;
+        command += ` --projectdir ${shq(projectDir.join(","))}`;
     }
 
     if (category && category.length > 0) {
-        command += ` --category "${category.join(",")}"`;
+        command += ` --category ${shq(category.join(","))}`;
     }
 
     if (format) {
-        command += ` --format ${format}`;
+        command += ` --format ${shq(format)}`;
     }
 
     if (outfile) {
-        command += ` --outfile "${outfile}"`;
+        command += ` --outfile ${shq(outfile)}`;
     }
 
     if (severityThreshold !== undefined) {
-        command += ` --severity-threshold ${severityThreshold}`;
+        command += ` --severity-threshold ${shq(severityThreshold)}`;
     }
 
     if (normalizeSeverity) {
@@ -132,11 +133,11 @@ const runScannerDfa = async (
     }
 
     if (ruleThreadCount !== undefined) {
-        command += ` --rule-thread-count ${ruleThreadCount}`;
+        command += ` --rule-thread-count ${shq(ruleThreadCount)}`;
     }
 
     if (ruleThreadTimeout !== undefined) {
-        command += ` --rule-thread-timeout ${ruleThreadTimeout}`;
+        command += ` --rule-thread-timeout ${shq(ruleThreadTimeout)}`;
     }
 
     if (ruleDisableWarningViolation) {
@@ -144,11 +145,11 @@ const runScannerDfa = async (
     }
 
     if (sfgeJvmArgs) {
-        command += ` --sfgejvmargs "${sfgeJvmArgs}"`;
+        command += ` --sfgejvmargs ${shq(sfgeJvmArgs)}`;
     }
 
     if (pathExpLimit !== undefined) {
-        command += ` --pathexplimit ${pathExpLimit}`;
+        command += ` --pathexplimit ${shq(pathExpLimit)}`;
     }
 
     const result = await executeSfCommandRaw(command);

--- a/src/tools/schema.ts
+++ b/src/tools/schema.ts
@@ -1,5 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { permissions } from "../config/permissions.js";
+import { shq } from "../utils/shellEscape.js";
 import { executeSfCommand } from "../utils/sfCommand.js";
 import z from "zod";
 
@@ -34,7 +35,7 @@ const schemaGenerateTab = async (
     }
 
     try {
-        let sfCommand = `sf schema generate tab --object "${object}" --directory "${directory}" --icon ${icon}`;
+        let sfCommand = `sf schema generate tab --object ${shq(object)} --directory ${shq(directory)} --icon ${shq(icon)}`;
 
         const result = await executeSfCommand(sfCommand);
         return { result };

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { executeSfCommandRaw } from "../utils/sfCommand.js";
+import { shq } from "../utils/shellEscape.js";
 import { permissions } from "../config/permissions.js";
 import { resolveTargetOrg } from "../utils/resolveTargetOrg.js";
 
@@ -13,9 +14,9 @@ const executeSoslQuery = async (
     let sfCommand: string;
 
     if (query) {
-        sfCommand = `sf data search --target-org ${targetOrg} --query "${query}" --result-format ${resultFormat}`;
+        sfCommand = `sf data search --target-org ${shq(targetOrg)} --query ${shq(query)} --result-format ${shq(resultFormat)}`;
     } else if (file) {
-        sfCommand = `sf data search --target-org ${targetOrg} --file "${file}" --result-format ${resultFormat}`;
+        sfCommand = `sf data search --target-org ${shq(targetOrg)} --file ${shq(file)} --result-format ${shq(resultFormat)}`;
     } else {
         throw new Error("Either query or file must be provided");
     }

--- a/src/tools/sobjects.ts
+++ b/src/tools/sobjects.ts
@@ -1,11 +1,12 @@
 import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { shq } from "../utils/shellEscape.js";
 import { executeSfCommand } from "../utils/sfCommand.js";
 import { permissions } from "../config/permissions.js";
 import { resolveTargetOrg } from "../utils/resolveTargetOrg.js";
 
 export const executeSobjectList = async (targetOrg: string) => {
-    const sfCommand = `sf sobject list --sobject all --target-org ${targetOrg} --json`;
+    const sfCommand = `sf sobject list --sobject all --target-org ${shq(targetOrg)} --json`;
 
     try {
         const result = await executeSfCommand(sfCommand);
@@ -19,7 +20,7 @@ export const executeSObjectDescribe = async (
     targetOrg: string,
     sObjectName: string,
 ) => {
-    const sfCommand = `sf sobject describe --sobject ${sObjectName} --target-org ${targetOrg} --json`;
+    const sfCommand = `sf sobject describe --sobject ${shq(sObjectName)} --target-org ${shq(targetOrg)} --json`;
 
     try {
         const result = await executeSfCommand(sfCommand);

--- a/src/utils/shellEscape.ts
+++ b/src/utils/shellEscape.ts
@@ -1,0 +1,23 @@
+/**
+ * POSIX shell-safe single-quote escaping for values interpolated into
+ * commands run via child_process.exec() (which executes through
+ * `/bin/sh -c` on macOS/Linux).
+ *
+ * Wrapping a value in single quotes and escaping any embedded single
+ * quote (`'` -> `'\''`) is sufficient to make the value inert to shell
+ * metacharacters (spaces, quotes, semicolons, backticks, `$()`, etc.)
+ * regardless of its content, because nothing inside a single-quoted
+ * string is interpreted by the shell.
+ *
+ * Scope note: this covers the POSIX shells used on macOS/Linux, which is
+ * where exec()'s injection risk is most severe (arbitrary shell metachar
+ * execution). Windows' cmd.exe has different, weaker quoting semantics
+ * (`^`, `%`, `&`) that single-quote escaping does not address — the
+ * long-term fix is moving off exec()/shell-string commands entirely to
+ * execFile()/spawn() with an argv array, which sidesteps shell parsing
+ * on every platform. Flagging that as a larger follow-up; this change
+ * closes the immediate, cross-platform-verified injection path.
+ */
+export function shq(value: string | number): string {
+    return `'${String(value).replace(/'/g, `'\\''`)}'`;
+}


### PR DESCRIPTION
Fixes the command-injection issue reported by email (query.ts, search.ts, and every other file that builds an `sf` CLI invocation as a shell string).

## Root cause

Every `sf` CLI command is built as a template-literal shell string with unescaped interpolation of caller-supplied values, then run through `exec()` (which executes via `/bin/sh -c`). A caller-supplied string containing a double quote plus shell metacharacters breaks out of its quoted argument and runs arbitrary commands as the user running the MCP server.

Example, from `query_records` / `search_records`:
```
FIND {test}" ; touch /tmp/pwned ; echo "
```

## Fix

Added `src/utils/shellEscape.ts` (`shq()`), a POSIX single-quote escaper, and wrapped every interpolated value in every sf-command-building call site across `query.ts`, `search.ts`, `project.ts`, `lightning.ts`, `schema.ts`, `code-analyzer.ts`, `orgs.ts`, `sobjects.ts`, `apex.ts`, `package.ts`, and `scanner.ts`.

Also found and fixed the same bug class in `records.ts`'s `openRecordInBrowser()` (opens a record's URL via `open`/`xdg-open`, built from a caller-supplied `recordId` with no format validation beyond non-empty) — not one of the files in the original report, found while auditing every `exec()` call site in the repo for the same pattern. Left the win32 `start` branch as-is with a comment: `shq()` targets POSIX shells and `cmd.exe`'s quoting rules differ, so that branch needs a separate escaper as a follow-up rather than a false sense of coverage.

## Verification

`scripts/verify-command-injection-fix.mjs` reproduces the exact command-construction + `exec()` logic used in `sfCommand.ts` (substituting `echo` for the real `sf` binary, no live Salesforce org touched) against both the vulnerable pattern and the fixed one, using the exact payload from the original report:

```
node scripts/verify-command-injection-fix.mjs
```

Confirms the payload executes as an injected shell command against the unescaped pattern, and is neutralized (reaches `echo` as inert single-quoted text) against the `shq()`-escaped one.

`npx tsc --noEmit` passes clean.

## Scope note

Single-quote escaping closes the immediate, verified injection path. The structurally cleaner fix is moving off `exec()`/shell strings to `execFile()`/`spawn()` with an argv array on every call site, which sidesteps shell parsing entirely and would also fix the win32 case — noted in `shellEscape.ts` as a suggested follow-up, kept out of scope here to keep this reviewable as a single, minimal, testable change.

No test framework exists in the repo currently, hence the standalone verification script rather than a test-suite addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)